### PR TITLE
Rename batch method to match README documentation

### DIFF
--- a/lib/factory_faster/batch.rb
+++ b/lib/factory_faster/batch.rb
@@ -8,7 +8,7 @@ module FactoryFaster
       @glob = glob
     end
 
-    def run
+    def process
       Dir.glob(glob).each do |filename|
         Faster.new(filename).process
       end


### PR DESCRIPTION
Hey there, nice project idea!  Just tried it out and noticed the method name was not in-line with the readme. Thanks!
